### PR TITLE
Add page number option to all method of tickets

### DIFF
--- a/lib/codebase_api/ticket.rb
+++ b/lib/codebase_api/ticket.rb
@@ -5,11 +5,11 @@ module CodebaseApi
 
 			# list the tickets for a project
 			def all(project, page_number = nil)
-        if page_number.is_a? Integer
-          CodebaseApi::Request.request("#{project}/tickets?page=#{page_number}")
-        else
-				  CodebaseApi::Request.request("#{project}/tickets")
-        end
+        			if page_number.is_a? Integer
+          				CodebaseApi::Request.request("#{project}/tickets?page=#{page_number}")
+        			else
+				  	CodebaseApi::Request.request("#{project}/tickets")
+        			end
 			end
 
 			# search all tickets

--- a/lib/codebase_api/ticket.rb
+++ b/lib/codebase_api/ticket.rb
@@ -4,14 +4,9 @@ module CodebaseApi
 		class << self
 
 			# list the tickets for a project
-			def all(project, num_pages = nil)
-        if num_pages
-          tickets = []
-          for i in 0..num_pages
-            result = CodebaseApi::Request.request("#{project}/tickets", :post, { :page => i } )
-            tickets = tickets + result if result
-          end
-          tickets
+			def all(project, page_number = nil)
+        if page_number.is_a? Integer
+          CodebaseApi::Request.request("#{project}/tickets?page=#{page_number}")
         else
 				  CodebaseApi::Request.request("#{project}/tickets")
         end

--- a/lib/codebase_api/ticket.rb
+++ b/lib/codebase_api/ticket.rb
@@ -4,8 +4,17 @@ module CodebaseApi
 		class << self
 
 			# list the tickets for a project
-			def all(project)
-				CodebaseApi::Request.request("#{project}/tickets")
+			def all(project, num_pages = nil)
+        if num_pages
+          tickets = []
+          for i in 0..num_pages
+            result = CodebaseApi::Request.request("#{project}/tickets", :post, { :page => i } )
+            tickets = tickets + result if result
+          end
+          tickets
+        else
+				  CodebaseApi::Request.request("#{project}/tickets")
+        end
 			end
 
 			# search all tickets


### PR DESCRIPTION
Codebase api paginates requests so it will only return 20 results at a time.  I'd like to add an option on the all tickets method that will let a user pass the page number in for situations that they need to get all tickets when there are more than 20.