### PR TITLE
Handle JSON Parser Error

### DIFF
--- a/lib/codebase_api/request.rb
+++ b/lib/codebase_api/request.rb
@@ -53,8 +53,8 @@ module CodebaseApi
               @output = http_result.body
             end
           rescue JSON::ParserError => e
-            ap "JSON PARSER ERROR"
-            ap e
+            puts "JSON PARSER ERROR"
+            puts e
           end
         else
           @output

--- a/lib/codebase_api/request.rb
+++ b/lib/codebase_api/request.rb
@@ -46,10 +46,15 @@ module CodebaseApi
       else
         if !http_result.body.empty?
           # render the output if it's a blob
-          if /\/blob\//.match(uri.request_uri).nil?
-            @output = JSON.parse(http_result.body)
-          else
-            @output = http_result.body
+          begin
+            if /\/blob\//.match(uri.request_uri).nil?
+              @output = JSON.parse(http_result.body)
+            else
+              @output = http_result.body
+            end
+          rescue JSON::ParserError => e
+            ap "JSON PARSER ERROR"
+            ap e
           end
         else
           @output


### PR DESCRIPTION
When I call `Codebase::TimeSession.delete` I get a  JSON Parser Error because the response from codebase is just a blank space.  I added a rescue statement to catch this and print the error, unless there is a better idea?
